### PR TITLE
Removed font-size to allow better customizability

### DIFF
--- a/valkyrie-material-light.css
+++ b/valkyrie-material-light.css
@@ -3,7 +3,6 @@
 .CodeMirror-scroll,
 .CodeMirror-gutters {
   font-family: "SourceCodePro-Medium";
-  font-size: 15px;
 }
 .cm-meta {
   color: #f44336;


### PR DESCRIPTION
specifying a certain font size overwrites the font size settings in brackets making them non-responsive.
